### PR TITLE
finishing v1 theme

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -22,17 +22,17 @@
 @media (prefers-color-scheme: dark) {
    
   ::-moz-selection {
-    background: #bcbcbc;
+    background: #f9fafb;
     color: #000000; /* Change this to your desired text color */
   }
   
   ::-webkit-selection {
-    background: #bcbcbc;
+    background: #f9fafb;
     color: #000000; /* Change this to your desired text color */
   }
   
   ::selection {
-    background: #bcbcbc;
+    background: #f9fafb;
     color: #000000; /* Change this to your desired text color */
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,11 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 254, 253, 240;
-  --background-end-rgb: 254, 253, 240;
-}
+
 
 ::-moz-selection {
   background: #2a2a2a;
@@ -24,11 +20,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-   :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 26, 26, 26;
-    --background-end-rgb: 26, 26, 26;
-  } 
+   
   ::-moz-selection {
     background: #bcbcbc;
     color: #000000; /* Change this to your desired text color */

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -17,6 +17,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <meta name="theme-color" content="#e2deda" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+      </head>
       <body className={inter.className}>{children}<Analytics/></body>
     </html>
   )

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,9 +6,9 @@ import { berkeleymono } from './fonts'
 
 export default function Home() {
   return (
-    <main className=" flex min-h-screen flex-col items-center justify-center">
+    <main className=" flex min-h-screen bg-bgLight dark:bg-bgDark flex-col items-center justify-center">
       {/* <div className="relative flex place-items-center before:absolute "> */}
-      <meta name="theme-color" content="#fefdf0 dark:##1a1a1a"></meta>
+      <meta name="theme-color" content="#e2deda dark:#292929"></meta>
       <div className={berkeleymono.className}>
       <div className='lg:pt-24 pt-56 '>
           <div className="grid grid-cols-10 lg:ml-10 md:pl-40 lg:px-32 sm:px-0 gap-2 sm:mt-20 mb-16 ">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,7 +8,8 @@ export default function Home() {
   return (
     <main className=" flex min-h-screen bg-bgLight dark:bg-bgDark flex-col items-center justify-center">
       {/* <div className="relative flex place-items-center before:absolute "> */}
-      <meta name="theme-color" content="#e2deda dark:#292929"></meta>
+      <meta name="theme-color" content="#e2deda" media="(prefers-color-scheme: light)"></meta>
+      <meta name="theme-color" content="#292929" media="(prefers-color-scheme: dark)"></meta>
       <div className={berkeleymono.className}>
       <div className='lg:pt-24 pt-56 '>
           <div className="grid grid-cols-10 lg:ml-10 md:pl-40 lg:px-32 sm:px-0 gap-2 sm:mt-20 mb-16 ">
@@ -27,7 +28,7 @@ export default function Home() {
             </span>
           </div>
           <div className=" col-end-3 lg:px-20  ">
-          <span className="text-xl bg-clip-text text-transparent text-international-orange tracking-tight font-light">2025</span>
+          <span className="text-xl bg-clip-text text-transparent text-international-orange-engineering dark:text-international-orange tracking-tight font-light">2025</span>
           </div>
           <div className="col-end-7 col-span-2 lg:px-20 pb-7 ">
           <span className="text-xl text-gray-600 tracking-tight font-normal dark:text-gray-50">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,8 +9,8 @@ export default function Home() {
   return (
     <>
     <Head>
-        <meta name="theme-color" content="#e2deda" media="(prefers-color-scheme: light)" />
-        <meta name="theme-color" content="#292929" media="(prefers-color-scheme: dark)" />
+        <meta name="theme-color" content="#e2deda"/>
+        <meta name="theme-color" content="#292929" media="(prefers-color-scheme: dark)"/>
       </Head>
     <main className=" flex min-h-screen bg-bgLight dark:bg-bgDark flex-col items-center justify-center">
       {/* <div className="relative flex place-items-center before:absolute "> */}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,14 +2,18 @@
 
 import Link from 'next/link'
 import { berkeleymono } from './fonts'
+import Head from 'next/head';
 
 
 export default function Home() {
   return (
+    <>
+    <Head>
+        <meta name="theme-color" content="#e2deda" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#292929" media="(prefers-color-scheme: dark)" />
+      </Head>
     <main className=" flex min-h-screen bg-bgLight dark:bg-bgDark flex-col items-center justify-center">
       {/* <div className="relative flex place-items-center before:absolute "> */}
-      <meta name="theme-color" content="#e2deda" media="(prefers-color-scheme: light)"></meta>
-      <meta name="theme-color" content="#292929" media="(prefers-color-scheme: dark)"></meta>
       <div className={berkeleymono.className}>
       <div className='lg:pt-24 pt-56 '>
           <div className="grid grid-cols-10 lg:ml-10 md:pl-40 lg:px-32 sm:px-0 gap-2 sm:mt-20 mb-16 ">
@@ -138,5 +142,6 @@ export default function Home() {
       </div>
       </div>
     </main>
+    </>
   )
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,8 +9,8 @@ export default function Home() {
   return (
     <>
     <Head>
-        <meta name="theme-color" content="#e2deda"/>
-        <meta name="theme-color" content="#292929" media="(prefers-color-scheme: dark)"/>
+        <meta name="theme-color" content="#e2deda dark:#1a1a1a" ></meta>
+        {/* <meta name="theme-color" content="#292929" media="(prefers-color-scheme: dark)"/> */}
       </Head>
     <main className=" flex min-h-screen bg-bgLight dark:bg-bgDark flex-col items-center justify-center">
       {/* <div className="relative flex place-items-center before:absolute "> */}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -99,7 +99,7 @@ export default function Home() {
         <div className="col-end-7 col-span-2 lg:pl-20">
   <div className='flex flex-row text-gray-600 dark:text-gray-50'>
     <div className="px-5">
-      <Link href="https://github.com/degstn/">
+      <Link href="https://github.com/degstn/" aria-label="GitHub profile">
         <svg
           width={25}
           height={25}
@@ -115,7 +115,7 @@ export default function Home() {
         </svg>
       </Link>
     </div>
-    <Link href="https://linkedin.com/in/degstn/">
+    <Link href="https://linkedin.com/in/degstn/" aria-label="LinkedIn profile">
       <svg
         width={25}
         height={25}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,16 +2,10 @@
 
 import Link from 'next/link'
 import { berkeleymono } from './fonts'
-import Head from 'next/head';
 
 
 export default function Home() {
   return (
-    <>
-    <Head>
-        <meta name="theme-color" content="#e2deda dark:#1a1a1a" ></meta>
-        {/* <meta name="theme-color" content="#292929" media="(prefers-color-scheme: dark)"/> */}
-      </Head>
     <main className=" flex min-h-screen bg-bgLight dark:bg-bgDark flex-col items-center justify-center">
       {/* <div className="relative flex place-items-center before:absolute "> */}
       <div className={berkeleymono.className}>
@@ -142,6 +136,5 @@ export default function Home() {
       </div>
       </div>
     </main>
-    </>
   )
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
       colors: {
         'international-orange': '#FF4F00',
         'international-orange-engineering': '#BA160C',
-        'disabled': '#d1d5db',
+        'disabled': '#9ca3af',
         'disabled-dark': '#4b5563',
         'gray-600': '#4b5563',
         'gray-50': '#f9fafb',

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
         'gray-600': '#4b5563',
         'gray-50': '#f9fafb',
         'bgLight': '#e2deda',
-        'bgDark': '#292929',
+        'bgDark': '#1a1a1a',
       },
     extend: {
       backgroundImage: {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -13,7 +13,9 @@ const config: Config = {
         'disabled': '#d1d5db',
         'disabled-dark': '#4b5563',
         'gray-600': '#4b5563',
-        'gray-50': '#f9fafb'
+        'gray-50': '#f9fafb',
+        'bgLight': '#e2deda',
+        'bgDark': '#292929',
       },
     extend: {
       backgroundImage: {


### PR DESCRIPTION
- contrast ratio for international orange on light color scheme
- added aria-descriptions for buttons with no text for accessibility
- changed background colors to fit in custom tailwind color list instead of using :root tags in globals.css
- changed selection colors from #bcbcbc –> #f9fafb
- changed background color on dark/light color schemes: #fefdf0 –> #e2deda

